### PR TITLE
Update getHelp default function name

### DIFF
--- a/src/getHelp.js
+++ b/src/getHelp.js
@@ -1,6 +1,6 @@
 import React from 'react'
 
-export default function getError({help, attrs}) {
+export default function getHelp({help, attrs}) {
   if (help) {
     return <span className="help-block" id={`${attrs.id}-tip'`}>{help}</span>
   }


### PR DESCRIPTION
The default function name was referencing getError.
