### PR TITLE
Bump tcomb version

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "classnames": "^2.1.3",
     "react": "^0.14.0",
-    "tcomb": "^2.5.0"
+    "tcomb": "^3.0.0"
   },
   "devDependencies": {
     "babel": "5.8.34",


### PR DESCRIPTION
This currently pulls in tcomb at v2.7.0. This is inconsistent with the latest tcomb-validation (and both are included by tcomb-form).
