### PR TITLE
Avoid key warnings on horizontal renders

### DIFF
--- a/src/date.js
+++ b/src/date.js
@@ -130,7 +130,7 @@ function create(overrides = {}) {
     const className = label ? locals.config.horizontal.getInputClassName() : locals.config.horizontal.getOffsetClassName()
     return [
       label,
-      <div className={classnames(className)}>
+      <div key="field-value" className={classnames(className)}>
         {date.renderDate(locals)}
         {date.renderError(locals)}
         {date.renderHelp(locals)}

--- a/src/getLabel.js
+++ b/src/getLabel.js
@@ -6,7 +6,7 @@ export default function getLabel({label, breakpoints, htmlFor, id}) {
     const className = breakpoints ? breakpoints.getLabelClassName() : {}
     className['control-label'] = true
     return (
-      <label htmlFor={htmlFor} id={id} className={classnames(className)}>{label}</label>
+      <label key="field-label" htmlFor={htmlFor} id={id} className={classnames(className)}>{label}</label>
     )
   }
 }

--- a/src/radio.js
+++ b/src/radio.js
@@ -87,7 +87,7 @@ function create(overrides = {}) {
     const className = label ? locals.config.horizontal.getInputClassName() : locals.config.horizontal.getOffsetClassName()
     return [
       label,
-      <div className={classnames(className)}>
+      <div key="field-value" className={classnames(className)}>
         {radio.renderRadios(locals)}
         {radio.renderError(locals)}
         {radio.renderHelp(locals)}

--- a/src/select.js
+++ b/src/select.js
@@ -98,7 +98,7 @@ function create(overrides = {}) {
     const className = label ? locals.config.horizontal.getInputClassName() : locals.config.horizontal.getOffsetClassName()
     return [
       label,
-      <div className={classnames(className)}>
+      <div key="field-value" className={classnames(className)}>
         {select.renderSelect(locals)}
         {select.renderError(locals)}
         {select.renderHelp(locals)}

--- a/src/textbox.js
+++ b/src/textbox.js
@@ -139,7 +139,7 @@ function create(overrides = {}) {
     const className = label ? locals.config.horizontal.getInputClassName() : locals.config.horizontal.getOffsetClassName()
     return [
       label,
-      <div className={classnames(className)}>
+      <div key="field-value" className={classnames(className)}>
         {textbox.renderTextbox(locals)}
         {textbox.renderError(locals)}
         {textbox.renderHelp(locals)}


### PR DESCRIPTION
React displays a ton of annoying key warnings when renderHorizontal is used on some fields. This is because the label and value are rendered as an array with no keys assigned to either element.
