### PR TITLE
=Remove quote from id

### DIFF
--- a/src/getHelp.js
+++ b/src/getHelp.js
@@ -2,6 +2,6 @@ import React from 'react'
 
 export default function getHelp({help, attrs}) {
   if (help) {
-    return <span className="help-block" id={`${attrs.id}-tip'`}>{help}</span>
+    return <span className="help-block" id={`${attrs.id}-tip`}>{help}</span>
   }
 }


### PR DESCRIPTION
There is a quote in the help-block id that should not be there.  This causes problems with screen readers as the ID doesn't match the aria-describedby attribute on the input.